### PR TITLE
Fix UINT32 and UINT8 for musl libc

### DIFF
--- a/rijndael.h
+++ b/rijndael.h
@@ -72,6 +72,13 @@ systems */
 	typedef u_char    UINT8;
 #endif
 
+/* Systems with musl libc have a sys/types.h with these definitions. */
+#if ! defined(_CRYPT_RIJNDAEL_H_TYPES) && defined(__DEFINED_uint32_t) && defined(__DEFINED_uint8_t)
+	#define _CRYPT_RIJNDAEL_H_TYPES
+	typedef uint32_t UINT32;
+	typedef uint8_t  UINT8;
+#endif
+
 /* I expect this to be the usual case */
 #if ! defined(_CRYPT_RIJNDAEL_H_TYPES) && ( defined(_SYS_TYPES_H) || defined(_SYS_TYPES_H_) )   
 	#define _CRYPT_RIJNDAEL_H_TYPES


### PR DESCRIPTION
I saw the comment in #11 about using U32 and U8 from perl, but hopefully this is an acceptable conservative change (note: not a C programmer).

Tested compilation on alpine 3.4 with musl 1.1.14.

The relevant musl source is here:
https://git.musl-libc.org/cgit/musl/tree/include/sys/types.h?h=v1.1.15&id=faf69b9a73d09fafcbe4fd3007b8d8724293d8e1

Closes #11
